### PR TITLE
Fixed two issues with the Dropout layer.

### DIFF
--- a/DeepFried2/layers/Dropout.py
+++ b/DeepFried2/layers/Dropout.py
@@ -14,10 +14,10 @@ class Dropout(df.Module):
             if symb_input.ndim == 4:
                 shuffle_shape += ('x', 'x')
 
-            mask = _srng.binomial((symb_input.shape[0], symb_input.shape[1]),
+            mask = _srng.binomial(symb_input.shape,
                                   p=(1. - self.dropout),
-                                  dtype='int32'
-                                  ).astype(df.floatX).dimshuffle(*shuffle_shape)
+                                  dtype=df.floatX
+                                  )
 
             return symb_input / (1. - self.dropout) * mask
         else:


### PR DESCRIPTION
- Changed the behavior from channel-wise dropout to entry-wise dropout. (As done in other well-known frameworks, e.g. Torch7, Lasagne and Toronto's Framework.)
- Changed the dtype passed to the binomial random stream. The int32 resulted in unnecessary type casts.
