### PR TITLE
The Critocalypse

### DIFF
--- a/DeepFried2/Container.py
+++ b/DeepFried2/Container.py
@@ -29,6 +29,9 @@ class Container(df.Module):
 
         return params, grads
 
+    def may_decay(self):
+        return sum((m.may_decay() for m in self.modules), [])
+
     def get_stat_updates(self):
         stat_updates = []
         for module in self.modules:

--- a/DeepFried2/Criterion.py
+++ b/DeepFried2/Criterion.py
@@ -1,5 +1,5 @@
 import DeepFried2 as df
-from DeepFried2.utils import make_tensor_or_tensors, aslist
+from DeepFried2.utils import make_tensor_or_tensors, aslist, typename
 
 
 class Criterion:
@@ -7,6 +7,10 @@ class Criterion:
     def __init__(self):
         self.penalties = []
         self._fn_forward = {}
+
+    def _assert_same_dim(self, symb_input, symb_target):
+        # A classic mistake, at least for myself.
+        assert symb_target.ndim == symb_input.ndim, "The targets of `{}` should have the same dimensionality as the net's output. You likely want to do something like `tgt[:,None]`.".format(typename(self))
 
     def symb_forward(self, symb_input, symb_target):
         raise NotImplementedError("`{}` needs to implement `symb_forward` method.".format(df.typename(self)))

--- a/DeepFried2/Criterion.py
+++ b/DeepFried2/Criterion.py
@@ -6,7 +6,7 @@ class Criterion:
     def __init__(self):
         self.penalties = []
 
-    def symb_forward(self, symb_inputs, symb_targets):
+    def symb_forward(self, symb_input, symb_target):
         raise NotImplementedError("`{}` needs to implement `symb_forward` method.".format(df.typename(self)))
 
     # TODO: Might actually want the weights to be shared variables so we can change their values on-the-fly!
@@ -17,8 +17,8 @@ class Criterion:
             weight, pen = weight_or_pen, pen
         self.penalties.append((weight, pen))
 
-    def full_symb_forward(self, symb_inputs, symb_targets):
-        cost = self.symb_forward(symb_input, symb_targets)
+    def full_symb_forward(self, symb_input, symb_target):
+        cost = self.symb_forward(symb_input, symb_target)
 
         for w, p in self.penalties:
             cost += w*p.symb_forward()

--- a/DeepFried2/Criterion.py
+++ b/DeepFried2/Criterion.py
@@ -1,0 +1,26 @@
+import DeepFried2 as df
+
+
+class Criterion:
+
+    def __init__(self):
+        self.penalties = []
+
+    def symb_forward(self, symb_inputs, symb_targets):
+        raise NotImplementedError("`{}` needs to implement `symb_forward` method.".format(df.typename(self)))
+
+    # TODO: Might actually want the weights to be shared variables so we can change their values on-the-fly!
+    def add_penalty(self, weight_or_pen, pen=None):
+        if pen is None:
+            weight, pen = 1.0, weight_or_pen
+        else:
+            weight, pen = weight_or_pen, pen
+        self.penalties.append((weight, pen))
+
+    def full_symb_forward(self, symb_inputs, symb_targets):
+        cost = self.symb_forward(symb_input, symb_targets)
+
+        for w, p in self.penalties:
+            cost += w*p.symb_forward()
+
+        return cost

--- a/DeepFried2/Module.py
+++ b/DeepFried2/Module.py
@@ -75,7 +75,7 @@ class Module:
             symb_in = make_tensor_or_tensors(data_in, 'X')
             symb_tgt = make_tensor_or_tensors(data_tgt, 'T')
             symb_out = self.symb_forward(symb_in)
-            symb_err = loss.symb_forward(symb_out, symb_tgt)
+            symb_err = loss.full_symb_forward(symb_out, symb_tgt)
 
             params, grads = self.unique_parameters()
             symb_grads = df.th.grad(cost=symb_err, wrt=params)

--- a/DeepFried2/Module.py
+++ b/DeepFried2/Module.py
@@ -50,6 +50,14 @@ class Module:
             list(_OrderedDict.fromkeys(grads).keys()),
         )
 
+    def may_decay(self):
+        flags = []
+        if hasattr(self, 'weight'):
+            flags += [True]
+        if hasattr(self, 'bias'):
+            flags += [False]
+        return flags
+
     def evaluate(self):
         self.training_mode = False
 

--- a/DeepFried2/__init__.py
+++ b/DeepFried2/__init__.py
@@ -10,6 +10,7 @@ from .layers import *
 from .Container import Container
 from .containers import *
 
+from .Criterion import Criterion
 from .criteria import *
 
 from .Optimizer import Optimizer

--- a/DeepFried2/criteria/BCECriterion.py
+++ b/DeepFried2/criteria/BCECriterion.py
@@ -11,8 +11,7 @@ class BCECriterion(df.Criterion):
         self.clip = clip
 
     def symb_forward(self, symb_input, symb_targets):
-        # A classic mistake, at least for myself.
-        assert symb_targets.ndim == symb_input.ndim, "The targets of `{}` should have the same dimensionality as the net's output. You likely want to do something like `tgt[:,None]`.".format(df.typename(self))
+        self._assert_same_dim(symb_input, symb_targets)
 
         if self.clip is not None:
             symb_input = df.T.clip(symb_input, self.clip, 1-self.clip)

--- a/DeepFried2/criteria/BCECriterion.py
+++ b/DeepFried2/criteria/BCECriterion.py
@@ -1,12 +1,13 @@
 import DeepFried2 as df
 
 
-class BCECriterion:
+class BCECriterion(df.Criterion):
     """
-    Like cross-entropy but also penalizing label-zero predictions.
+    Like cross-entropy but also penalizing label-zero predictions directly.
     """
 
     def __init__(self, clip=None):
+        df.Criterion.__init__(self)
         self.clip = clip
 
     def symb_forward(self, symb_input, symb_targets):

--- a/DeepFried2/criteria/ClassNLLCriterion.py
+++ b/DeepFried2/criteria/ClassNLLCriterion.py
@@ -1,8 +1,9 @@
 import DeepFried2 as df
 
 
-class ClassNLLCriterion:
+class ClassNLLCriterion(df.Criterion):
     def __init__(self, clip=None):
+        df.Criterion.__init__(self)
         self.clip = clip
 
     def symb_forward(self, symb_input, symb_targets):

--- a/DeepFried2/criteria/MADCriterion.py
+++ b/DeepFried2/criteria/MADCriterion.py
@@ -1,6 +1,6 @@
 import DeepFried2 as df
 
 
-class MADCriterion:
+class MADCriterion(df.Criterion):
     def symb_forward(self, symb_input, symb_target):
         return df.T.mean(abs(symb_input - symb_target))

--- a/DeepFried2/criteria/MADCriterion.py
+++ b/DeepFried2/criteria/MADCriterion.py
@@ -3,4 +3,6 @@ import DeepFried2 as df
 
 class MADCriterion(df.Criterion):
     def symb_forward(self, symb_input, symb_target):
+        self._assert_same_dim(symb_input, symb_target)
+
         return df.T.mean(abs(symb_input - symb_target))

--- a/DeepFried2/criteria/ParallelCriterion.py
+++ b/DeepFried2/criteria/ParallelCriterion.py
@@ -1,34 +1,29 @@
-class ParallelCriterion:
+import DeepFried2 as df
+
+
+class ParallelCriterion(df.Criterion):
     # TODO: Might actually want the weights to be shared variables so we can change their values on-the-fly!
-    def __init__(self, *weighted_criteria, repeat_target=False, penalties=None):
+    def __init__(self, *weighted_criteria, repeat_target=False):
+        df.Criterion.__init__(self)
         self.repeat_target = repeat_target
         self.criteria = []
-        self.penalties = []
 
         for wc in weighted_criteria:
-            self.add(*wc)
-        for wp in penalties:
-            self.add_penalty(*wp)
-
-    def _add(self, cont, weight_or_crit, crit=None):
-        if crit is None:
-            weight, crit = 1.0, weight_or_crit
-        else:
-            weight, crit = weight_or_crit, crit
-
-        cont.append((weight, crit))
+            self.add(*df.utils.aslist(wc))
 
     def add(self, weight_or_crit, crit=None):
-        self._add(self.criteria, weight_or_crit, crit)
-
-    def add_penalty(self, weight_or_crit, crit=None):
-        self._add(self.penalties, weight_or_crit, crit)
+        if crit is None:
+            self.criteria.append((1.0, weight_or_crit))
+        else:
+            self.criteria.append((weight_or_crit, crit))
 
     def symb_forward(self, symb_inputs, symb_targets):
+        symb_inputs = df.utils.aslist(symb_inputs)
+        symb_targets = df.utils.aslist(symb_targets)
+
         if self.repeat_target:
             symb_targets = [symb_targets] * len(symb_inputs)
 
         assert len(symb_inputs) == len(symb_targets) == len(self.criteria), "`{}` mismatch in number of inputs ({}), criteria ({}) and targets ({})" .format(df.typename(self), len(symb_inputs), len(self.criteria), len(symb_targets))
 
-        return sum(w*c.symb_forward(i, t) for (w,c), i, t in zip(self.criteria, symb_inputs, symb_targets)) \
-             + sum(w*p.symb_forward() for (w,p) in self.penalties)
+        return sum(w*c.symb_forward(i, t) for (w,c), i, t in zip(self.criteria, symb_inputs, symb_targets))

--- a/DeepFried2/criteria/ParallelCriterion.py
+++ b/DeepFried2/criteria/ParallelCriterion.py
@@ -1,0 +1,24 @@
+class ParallelCriterion:
+    # TODO: Might actually want the weights to be shared variables so we can change their values on-the-fly!
+    def __init__(self, *weighted_criteria, repeat_target=False):
+        self.repeat_target = repeat_target
+        self.criteria = []
+
+        for wc in weighted_criteria:
+            self.add(*wc)
+
+    def add(self, weight_or_crit, crit=None):
+        if crit is None:
+            weight, crit = 1.0, weight_or_crit
+        else:
+            weight, crit = weight_or_crit, crit
+
+        self.criteria.append((weight, crit))
+
+    def symb_forward(self, symb_inputs, symb_targets):
+        if self.repeat_target:
+            symb_targets = [symb_targets] * len(symb_inputs)
+
+        assert len(symb_inputs) == len(symb_targets) == len(self.criteria), "`{}` mismatch in number of inputs ({}), criteria ({}) and targets ({})" .format(df.typename(self), len(symb_inputs), len(self.criteria), len(symb_targets))
+
+        return sum(w*c.symb_forward(i, t) for (w,c), i, t in zip(self.criteria, symb_inputs, symb_targets))

--- a/DeepFried2/criteria/ParallelCriterion.py
+++ b/DeepFried2/criteria/ParallelCriterion.py
@@ -1,19 +1,28 @@
 class ParallelCriterion:
     # TODO: Might actually want the weights to be shared variables so we can change their values on-the-fly!
-    def __init__(self, *weighted_criteria, repeat_target=False):
+    def __init__(self, *weighted_criteria, repeat_target=False, penalties=None):
         self.repeat_target = repeat_target
         self.criteria = []
+        self.penalties = []
 
         for wc in weighted_criteria:
             self.add(*wc)
+        for wp in penalties:
+            self.add_penalty(*wp)
 
-    def add(self, weight_or_crit, crit=None):
+    def _add(self, cont, weight_or_crit, crit=None):
         if crit is None:
             weight, crit = 1.0, weight_or_crit
         else:
             weight, crit = weight_or_crit, crit
 
-        self.criteria.append((weight, crit))
+        cont.append((weight, crit))
+
+    def add(self, weight_or_crit, crit=None):
+        self._add(self.criteria, weight_or_crit, crit)
+
+    def add_penalty(self, weight_or_crit, crit=None):
+        self._add(self.penalties, weight_or_crit, crit)
 
     def symb_forward(self, symb_inputs, symb_targets):
         if self.repeat_target:
@@ -21,4 +30,5 @@ class ParallelCriterion:
 
         assert len(symb_inputs) == len(symb_targets) == len(self.criteria), "`{}` mismatch in number of inputs ({}), criteria ({}) and targets ({})" .format(df.typename(self), len(symb_inputs), len(self.criteria), len(symb_targets))
 
-        return sum(w*c.symb_forward(i, t) for (w,c), i, t in zip(self.criteria, symb_inputs, symb_targets))
+        return sum(w*c.symb_forward(i, t) for (w,c), i, t in zip(self.criteria, symb_inputs, symb_targets)) \
+             + sum(w*p.symb_forward() for (w,p) in self.penalties)

--- a/DeepFried2/criteria/RMSECriterion.py
+++ b/DeepFried2/criteria/RMSECriterion.py
@@ -1,11 +1,11 @@
 import DeepFried2 as df
 
 
-class RMSECriterion:
+class RMSECriterion(df.Criterion):
     def symb_forward(self, symb_input, symb_target):
         return df.T.mean(df.T.sqrt(df.T.sum((symb_input - symb_target)**2, axis=1)))
 
 
-class MSECriterion:
+class MSECriterion(df.Criterion):
     def symb_forward(self, symb_input, symb_target):
         return df.T.mean(df.T.sum((symb_input - symb_target)**2, axis=1))

--- a/DeepFried2/criteria/RMSECriterion.py
+++ b/DeepFried2/criteria/RMSECriterion.py
@@ -3,9 +3,13 @@ import DeepFried2 as df
 
 class RMSECriterion(df.Criterion):
     def symb_forward(self, symb_input, symb_target):
+        self._assert_same_dim(symb_input, symb_target)
+
         return df.T.mean(df.T.sqrt(df.T.sum((symb_input - symb_target)**2, axis=1)))
 
 
 class MSECriterion(df.Criterion):
     def symb_forward(self, symb_input, symb_target):
+        self._assert_same_dim(symb_input, symb_target)
+
         return df.T.mean(df.T.sum((symb_input - symb_target)**2, axis=1))

--- a/DeepFried2/criteria/WeightDecay.py
+++ b/DeepFried2/criteria/WeightDecay.py
@@ -1,6 +1,8 @@
 import DeepFried2 as df
 
 from itertools import chain
+# NOTE: We intentionally don't make these inherit from df.Criterion as we don't
+#       really want them to be used as standalone criteria.
 
 
 class L1WeightDecay:

--- a/DeepFried2/criteria/WeightDecay.py
+++ b/DeepFried2/criteria/WeightDecay.py
@@ -1,0 +1,23 @@
+import DeepFried2 as df
+
+from itertools import chain
+
+
+class L1WeightDecay:
+    def __init__(self, *containers):
+        self.containers = containers
+
+    def symb_forward(self):
+        # TODO: Not sure if unique or non-unique make more sense!
+        params = (c.unique_parameters()[0] for c in self.containers)
+        return sum(df.T.sum(abs(p)) for p in chain(*params))
+
+
+class L2WeightDecay:
+    def __init__(self, *containers):
+        self.containers = containers
+
+    def symb_forward(self):
+        # TODO: Not sure if unique or non-unique make more sense!
+        params = (c.unique_parameters()[0] for c in self.containers)
+        return sum(df.T.sum(p**2) for p in chain(*params))

--- a/DeepFried2/criteria/__init__.py
+++ b/DeepFried2/criteria/__init__.py
@@ -3,3 +3,4 @@ from .ClassNLLCriterion import ClassNLLCriterion
 from .BCECriterion import BCECriterion
 from .RMSECriterion import RMSECriterion, MSECriterion
 from .MADCriterion import MADCriterion
+from .WeightDecay import L1WeightDecay, L2WeightDecay

--- a/DeepFried2/criteria/__init__.py
+++ b/DeepFried2/criteria/__init__.py
@@ -1,3 +1,4 @@
+from .ParallelCriterion import ParallelCriterion
 from .ClassNLLCriterion import ClassNLLCriterion
 from .BCECriterion import BCECriterion
 from .RMSECriterion import RMSECriterion, MSECriterion

--- a/examples/MultipleOutputs/model.py
+++ b/examples/MultipleOutputs/model.py
@@ -1,0 +1,27 @@
+import DeepFried2 as df
+
+
+def cnn(size, *head):
+    return df.Sequential(
+        df.Reshape(-1, 3, size, size),
+
+        df.SpatialConvolutionCUDNN(3, 32, 3, 3, border='same', with_bias=False),
+        df.BatchNormalization(32), df.ReLU(),
+        df.SpatialConvolutionCUDNN(32, 32, 3, 3, border='same', with_bias=False),
+        df.BatchNormalization(32), df.ReLU(),
+        df.SpatialMaxPoolingCUDNN(2, 2),
+
+        df.SpatialConvolutionCUDNN(32, 64, 3, 3, border='same', with_bias=False),
+        df.BatchNormalization(64), df.ReLU(),
+        df.SpatialConvolutionCUDNN(64, 64, 3, 3, border='same', with_bias=False),
+        df.BatchNormalization(64), df.ReLU(),
+        df.SpatialMaxPoolingCUDNN(2, 2),
+
+        df.Reshape(-1, 64*(size//4)**2),
+
+        df.Linear(64*(size//4)**2, 1024, with_bias=False),
+        df.BatchNormalization(1024), df.ReLU(),
+        df.Dropout(0.5),
+
+        *head
+    )

--- a/examples/MultipleOutputs/run.py
+++ b/examples/MultipleOutputs/run.py
@@ -17,13 +17,11 @@ def main(params):
     )
 
     crit = df.ParallelCriterion(
-        (1, df.ClassNLLCriterion()),
-        (1, df.ClassNLLCriterion()),
-        penalties=[
-            (1e-4, df.L1WeightDecay(model)),
-            (1e-5, df.L2WeightDecay(model)),
-        ]
+        (0.75, df.ClassNLLCriterion()),
+        df.ClassNLLCriterion() # No weight defaults to one.
     )
+    crit.add_penalty(1e-4, df.L1WeightDecay(model))
+    crit.add_penalty(1e-5, df.L2WeightDecay(model))
 
     optim = df.AdaDelta(params['adadelta_rho'])
 

--- a/examples/MultipleOutputs/run.py
+++ b/examples/MultipleOutputs/run.py
@@ -1,0 +1,42 @@
+import DeepFried2 as df
+
+from train import *
+from test import *
+from model import *
+
+
+def main(params):
+    # c ^= coarse, f ^= fine
+    (Xtr, ytr_c, ytr_f), (Xva, yva_c, yva_f), (Xte, yte_c, yte_f), (le_c, le_f) = df.datasets.cifar100.data()
+
+    model = cnn(32,
+        df.Parallel(
+            df.Sequential(df.Linear(1024, 20, initW=df.init.const(0)), df.SoftMax()),
+            df.Sequential(df.Linear(1024,100, initW=df.init.const(0)), df.SoftMax()),
+        )
+    )
+
+    crit = df.ParallelCriterion(
+        (1, df.ClassNLLCriterion()),
+        (1, df.ClassNLLCriterion()),
+    )
+
+    optim = df.AdaDelta(params['adadelta_rho'])
+
+    for epoch in range(100):
+        model.training()
+        train(Xtr, ytr_c, ytr_f, model, optim, crit, epoch, params['batch_size'], 'train')
+
+        train(Xtr, ytr_c, ytr_f, model, optim, crit, epoch, params['batch_size'], 'stats')
+        model.evaluate()
+        validate(Xva, yva_c, yva_f, model, epoch, params['batch_size'])
+
+
+if __name__ == "__main__":
+    if __package__ is None:  # PEP366
+        __package__ = "DeepFried2.examples.MultipleOutputs"
+
+    params = {}
+    params['adadelta_rho'] = 0.95
+    params['batch_size'] = 128
+    main(params)

--- a/examples/MultipleOutputs/run.py
+++ b/examples/MultipleOutputs/run.py
@@ -19,6 +19,10 @@ def main(params):
     crit = df.ParallelCriterion(
         (1, df.ClassNLLCriterion()),
         (1, df.ClassNLLCriterion()),
+        penalties=[
+            (1e-4, df.L1WeightDecay(model)),
+            (1e-5, df.L2WeightDecay(model)),
+        ]
     )
 
     optim = df.AdaDelta(params['adadelta_rho'])

--- a/examples/MultipleOutputs/test.py
+++ b/examples/MultipleOutputs/test.py
@@ -1,0 +1,29 @@
+import DeepFried2 as df
+import numpy as np
+
+from examples.utils import make_progressbar
+
+
+def validate(X, y_c, y_f, model, epoch, batch_size):
+    progress = make_progressbar('Testing epoch #{}'.format(epoch), len(X))
+    progress.start()
+
+    nerrors_c, nerrors_f = 0, 0
+    for ibatch in range((len(X) + batch_size - 1) // batch_size):
+        # Note: numpy correctly handles the size of the last minibatch.
+        Xbatch = X[ibatch*batch_size : (ibatch+1)*batch_size].astype(df.floatX)
+        ybatch_c = y_c[ibatch*batch_size : (ibatch+1)*batch_size].astype(df.floatX)
+        ybatch_f = y_f[ibatch*batch_size : (ibatch+1)*batch_size].astype(df.floatX)
+
+        (preds_c, preds_f) = map(lambda py: np.argmax(py, axis=1), model.forward(Xbatch))
+
+        nerrors_c += sum(ybatch_c != preds_c)
+        nerrors_f += sum(ybatch_f != preds_f)
+
+        progress.update(ibatch*batch_size + len(Xbatch))
+
+    progress.finish()
+    accuracy_c = 1 - float(nerrors_c)/len(X)
+    accuracy_f = 1 - float(nerrors_f)/len(X)
+    print("Epoch #{}, Coarse accuracy: {:.2%} ({} errors)".format(epoch, accuracy_c, nerrors_c))
+    print("Epoch #{}, Fine   accuracy: {:.2%} ({} errors)".format(epoch, accuracy_f, nerrors_f))

--- a/examples/MultipleOutputs/train.py
+++ b/examples/MultipleOutputs/train.py
@@ -1,0 +1,30 @@
+import DeepFried2 as df
+import numpy as np
+
+from examples.utils import make_progressbar
+
+
+def train(X, y_c, y_f, model, optim, crit, epoch, batch_size, mode='train'):
+    progress = make_progressbar('Training ({}) epoch #{}'.format(mode, epoch), len(X))
+    progress.start()
+
+    shuffle = np.random.permutation(len(X))
+
+    for ibatch in range(len(X) // batch_size):
+        indices = shuffle[ibatch*batch_size : (ibatch+1)*batch_size]
+        Xbatch = X[indices].astype(df.floatX)
+        ybatch_c = y_c[indices].astype(df.floatX)
+        ybatch_f = y_f[indices].astype(df.floatX)
+
+        if mode == 'train':
+            model.zero_grad_parameters()
+            model.accumulate_gradients(Xbatch, (ybatch_c, ybatch_f), crit)
+            optim.update_parameters(model)
+        elif mode == 'stats':
+            model.accumulate_statistics(Xbatch)
+        else:
+            assert False, "Mode should be either 'train' or 'stats'"
+
+        progress.update(ibatch*batch_size + len(Xbatch))
+
+    progress.finish()


### PR DESCRIPTION
A substantial change to criteria.
1. All criteria inherit a base-class.
2. Through that base-class, all criteria support extra-penalties such as weight decay.
3. Parameters must be marked as decayable or not through the `Module.may_decay` method, which has sensible defaults.
4. Added `ParallelCriterion` which supports multiple criteria for [optimizing ALL the things](http://i.imgur.com/EnEfJQL.jpg) "jointly".

I'm especially unsatisfied with the way 3. is implemented, but Torch hasn't solved that problem elegantly either. I don't want to make `parameters` return a 3rd array indicating decayability, as ideally only the criteria care about that.

I'll leave this PR hanging for a small while and roll with it locally to see how it pans out. Any feedback welcome.
