### PR TITLE
consistent expected ordering of input for 3D related layers

### DIFF
--- a/DeepFried2/layers/BatchNormalization.py
+++ b/DeepFried2/layers/BatchNormalization.py
@@ -32,8 +32,8 @@ class BatchNormalization(df.Module):
             d_shuffle += ('x', 'x')
             axis += (2, 3)
         elif symb_input.ndim == 5:
-            d_shuffle = ('x', 'x', 0, 'x', 'x')
-            axis = (0, 1, 3, 4)
+            d_shuffle += ('x', 'x', 'x')
+            axis += (2, 3, 4)
 
         if self.training_mode:
             self.batch_mean = df.T.mean(symb_input, axis=axis)

--- a/DeepFried2/layers/SpatialConvolution3D.py
+++ b/DeepFried2/layers/SpatialConvolution3D.py
@@ -25,17 +25,23 @@ class SpatialConvolution3D(df.Module):
 
     def symb_forward(self, symb_input):
 
-        """symb_input shape: (n_input, depth, channels, height, width)"""
+        """symb_input shape: (n_input, channels, depth, height, width)"""
 
         if symb_input.ndim < 5:
             raise NotImplementedError('3D convolution requires a dimension >= 5')
+
+        # shuffle bcd01 -> bdc01
+        symb_input = symb_input.swapaxes(1,2)
 
         conv_output = conv3d2d.conv3d(symb_input,
                                       self.weight,
                                       filters_shape=self.w_shape,
                                       border_mode=self.border_mode)
 
+        # shuffle bdc01 -> bcd01
+        conv_output = conv_output.swapaxes(1,2)
+
         if self.with_bias:
-            return conv_output + self.bias.dimshuffle('x', 'x', 0, 'x', 'x')
+            return conv_output + self.bias.dimshuffle('x', 0, 'x', 'x', 'x')
         else:
             return conv_output

--- a/DeepFried2/layers/SpatialMaxPooling3D.py
+++ b/DeepFried2/layers/SpatialMaxPooling3D.py
@@ -28,7 +28,8 @@ class SpatialMaxPooling3D(df.Module):
 
     def symb_forward(self, symb_input):
         """ 3d max pooling taken from github.com/lpigou/Theano-3D-ConvNet/
-            (with modified shuffeling) """
+            (with modified shuffeling)
+            symb_input shape: (n_input, channels, depth, height, width)"""
         if symb_input.ndim < 5:
             raise NotImplementedError('max pooling 3D requires a dimension >= 5')
 
@@ -51,7 +52,7 @@ class SpatialMaxPooling3D(df.Module):
 
         vol_dim = symb_input.ndim
 
-        shufl = (list(range(vol_dim-4)) + [vol_dim-2]+[vol_dim-1]+[vol_dim-3]+[vol_dim-4])
+        shufl = (list(range(vol_dim-4)) + [vol_dim-2]+[vol_dim-1]+[vol_dim-4]+[vol_dim-3])
         input_depth = out.dimshuffle(shufl)
         vol_shape = input_depth.shape[-2:]
 
@@ -67,6 +68,6 @@ class SpatialMaxPooling3D(df.Module):
         outdepth = op(input_4D_depth)
 
         outshape = _T.join(0, input_depth.shape[:-2], outdepth.shape[-2:])
-        shufl = (list(range(vol_dim-4)) + [vol_dim-1]+[vol_dim-2]+[vol_dim-4]+[vol_dim-3])
+        shufl = (list(range(vol_dim-4)) + [vol_dim-2]+[vol_dim-1]+[vol_dim-4]+[vol_dim-3])
 
         return _T.reshape(outdepth, outshape, ndim=symb_input.ndim).dimshuffle(shufl)


### PR DESCRIPTION
This makes the ordering for the input consistent with the CUDNN format (n_input, channels, depth, height, width)
