### PR TITLE
Make container's `[]` more flexible:

### DIFF
--- a/DeepFried2/Container.py
+++ b/DeepFried2/Container.py
@@ -43,8 +43,13 @@ class Container(df.Module):
             assert isinstance(m, df.Module), "`{}`s can only contain objects subtyping `df.Module`. You tried to add the following `{}`: {}".format(df.typename(self), df.typename(m), m)
         self.modules += modules
 
-    def __getitem__(self, slice_):
-        return type(self)(*df.utils.aslist(self.modules[slice_]))
+    def __getitem__(self, key):
+        if isinstance(key, slice):
+            return type(self)(*df.utils.aslist(self.modules[key]))
+        elif isinstance(key, (list, tuple)):
+            return type(self)(*[self.modules[k] for k in key])
+        else:
+            return self.modules[key]
 
     def __getstate__(self):
         return [m.__getstate__() for m in self.modules]


### PR DESCRIPTION
- For a slice, still return a container of the same type.
  E.g. `net[:3]` still works as before.
- For a single key, return that one module of the container, not
  contained anymore.
  E.g. make `net[1]` return a module.
- For a list or tuple key, return a container of the same type only
  containing those modules indexed in the list/tuple.
  E.g. make `net[[0,3,5]]` returne a container with these 3 modules.
