### PR TITLE
Address comments in #48

### DIFF
--- a/DeepFried2/layers/BackwardsConvolutionCUDNN.py
+++ b/DeepFried2/layers/BackwardsConvolutionCUDNN.py
@@ -1,5 +1,5 @@
 import DeepFried2 as df
-from DeepFried2.utils import create_param_and_grad
+from DeepFried2.utils import create_param_and_grad, expand
 from theano.sandbox.cuda.basic_ops import gpu_contiguous, gpu_alloc_empty
 from theano.sandbox.cuda import dnn
 
@@ -7,39 +7,34 @@ import numpy as np
 
 
 class BackwardsConvolutionCUDNN(df.Module):
-    def __init__(self, n_input_plane, n_output_plane, filter_size, stride=(1,1), padding=(0,0), mode='cross', with_bias=True, initW=df.init.xavier(), initB=df.init.const(0), border=None):
+    def __init__(self, nchan_in, nchan_out, filter_size, stride=1, border_mode=0, mode='cross', with_bias=True, initW=df.init.xavier(), initB=df.init.const(0)):
         # mode='cross' is the default in Lasagne[1], Torch[2], matConvNet[3], Caffee[4].
         #
         # 1: https://github.com/Lasagne/Lasagne/blob/63d44a0d/lasagne/layers/dnn.py#L299
         # 2: https://github.com/soumith/cudnn.torch/blob/840f0228/SpatialConvolution.lua#L83
         # 3: https://github.com/vlfeat/matconvnet/blob/b7dd9c96/matlab/src/bits/impl/nnconv_cudnn.cu#L133
         # 4: https://github.com/BVLC/caffe/blob/50ab52cb/include/caffe/util/cudnn.hpp#L104
-
         df.Module.__init__(self)
-        self.n_input_plane = n_input_plane
-        self.n_output_plane = n_output_plane
+        self.nchan_in = nchan_in
+        self.nchan_out = nchan_out
         self.filter_size = filter_size
-        self.stride = stride
         self.mode = mode
         self.with_bias = with_bias
+        self.stride = expand(stride, len(filter_size), 'stride')
+        self.border = expand(border_mode, len(filter_size), 'border_mode')
 
-        assert len(self.stride) == len(self.filter_size), 'The dimensionality of the stride and the filter size should match.'
         # 'same' is a (common) shortcut for "zero-padding so that outshape == inshape".
-        self.border = border or padding
         if self.border == 'same':
             assert all(k % 2 == 1 for k in self.filter_size), "'same' convolution only supports odd filter sizes."
-
             self.border = tuple( (k - 1)//2 for k in self.filter_size )
 
-        assert len(self.border) == len(self.stride), 'The dimensionality of the stride and the padding should match.'
-
-        w_shape = (n_input_plane, n_output_plane) + self.filter_size
-        w_fan = (np.prod(self.filter_size)*n_output_plane, np.prod(self.filter_size)*n_input_plane)
+        w_shape = (nchan_in, nchan_out) + self.filter_size
+        w_fan = (np.prod(self.filter_size)*nchan_out, np.prod(self.filter_size)*nchan_in)
 
         param_name = 'Wconv_{},{}@{}' + 'x{}'*(len(w_shape) - 3)
         self.weight, self.grad_weight = create_param_and_grad(w_shape, initW, fan=w_fan, name=param_name.format(*w_shape))
         if self.with_bias:
-            self.bias, self.grad_bias = create_param_and_grad(n_output_plane, initB, name='bconv_{}'.format(n_output_plane))
+            self.bias, self.grad_bias = create_param_and_grad(nchan_out, initB, name='bconv_{}'.format(nchan_out))
 
 
     def symb_forward(self, symb_input):
@@ -56,6 +51,6 @@ class BackwardsConvolutionCUDNN(df.Module):
 
         if self.with_bias:
             d_shuffle = ('x', 0) + tuple('x') * (symb_input.ndim-2)
-            return conv_output + self.bias.dimshuffle(*d_shuffle)
-        else:
-            return conv_output
+            conv_output += self.bias.dimshuffle(*d_shuffle)
+
+        return conv_output

--- a/DeepFried2/layers/SpatialConvolutionCUDNN.py
+++ b/DeepFried2/layers/SpatialConvolutionCUDNN.py
@@ -1,44 +1,39 @@
 import DeepFried2 as df
-from DeepFried2.utils import create_param_and_grad
+from DeepFried2.utils import create_param_and_grad, expand
 from theano.sandbox.cuda import dnn
 
 import numpy as np
 
 class SpatialConvolutionCUDNN(df.Module):
-    def __init__(self, n_input_plane, n_output_plane, filter_size, stride=(1,1), padding=(0,0), mode='cross', with_bias=True, initW=df.init.xavier(), initB=df.init.const(0), border=None):
+    def __init__(self, nchan_in, nchan_out, filter_size, stride=1, border_mode=0, mode='cross', with_bias=True, initW=df.init.xavier(), initB=df.init.const(0)):
         # mode='cross' is the default in Lasagne[1], Torch[2], matConvNet[3], Caffee[4].
         #
         # 1: https://github.com/Lasagne/Lasagne/blob/63d44a0d/lasagne/layers/dnn.py#L299
         # 2: https://github.com/soumith/cudnn.torch/blob/840f0228/SpatialConvolution.lua#L83
         # 3: https://github.com/vlfeat/matconvnet/blob/b7dd9c96/matlab/src/bits/impl/nnconv_cudnn.cu#L133
         # 4: https://github.com/BVLC/caffe/blob/50ab52cb/include/caffe/util/cudnn.hpp#L104
-        #
-        # `border` is an alternative way to specify `pad_w` and `pad_h` so that Theano strings can be used. Better documentation to follow soon.
         df.Module.__init__(self)
-        self.n_input_plane = n_input_plane
-        self.n_output_plane = n_output_plane
+        self.nchan_in = nchan_in
+        self.nchan_out = nchan_out
         self.filter_size = filter_size
-        self.stride = stride
         self.mode = mode
         self.with_bias = with_bias
+        self.stride = expand(stride, len(filter_size), 'stride')
+        self.border = expand(border_mode, len(filter_size), 'border_mode')
 
-        assert len(self.stride) == len(self.filter_size), 'The dimensionality of the stride and the filter size should match.'
         # 'same' is a (common) shortcut for "zero-padding so that outshape == inshape".
-        self.border = border or padding
         if self.border == 'same':
             assert all(k % 2 == 1 for k in self.filter_size), "'same' convolution only supports odd filter sizes."
-
             self.border = tuple( (k - 1)//2 for k in self.filter_size )
 
-        assert len(self.border) == len(self.stride), 'The dimensionality of the stride and the padding should match.'
-
-        w_shape = (n_output_plane, n_input_plane) + self.filter_size
-        w_fan = (np.prod(self.filter_size)*n_input_plane, np.prod(self.filter_size)*n_output_plane)
+        w_shape = (nchan_out, nchan_in) + self.filter_size
+        w_fan = (np.prod(self.filter_size)*nchan_in, np.prod(self.filter_size)*nchan_out)
 
         param_name = 'Wconv_{},{}@{}' + 'x{}'*(len(w_shape) - 3)
         self.weight, self.grad_weight = create_param_and_grad(w_shape, initW, fan=w_fan, name=param_name.format(*w_shape))
         if self.with_bias:
-            self.bias, self.grad_bias = create_param_and_grad(n_output_plane, initB, name='bconv_{}'.format(n_output_plane))
+            self.bias, self.grad_bias = create_param_and_grad(nchan_out, initB, name='bconv_{}'.format(nchan_out))
+
 
     def symb_forward(self, symb_input):
         conv = dnn.dnn_conv3d if symb_input.ndim == 5 else dnn.dnn_conv
@@ -53,6 +48,6 @@ class SpatialConvolutionCUDNN(df.Module):
 
         if self.with_bias:
             d_shuffle = ('x', 0) + tuple('x') * (symb_input.ndim-2)
-            return conv_output + self.bias.dimshuffle(*d_shuffle)
-        else:
-            return conv_output
+            conv_output += self.bias.dimshuffle(*d_shuffle)
+
+        return conv_output

--- a/DeepFried2/layers/SpatialMaxPooling.py
+++ b/DeepFried2/layers/SpatialMaxPooling.py
@@ -1,6 +1,5 @@
 import DeepFried2 as df
 from theano.tensor.signal.downsample import max_pool_2d
-import theano.tensor as _T
 
 
 class SpatialMaxPooling(df.Module):
@@ -15,7 +14,7 @@ class SpatialMaxPooling(df.Module):
             self.stride = stride
 
         if padding is None:
-            self.padding = tuple([0] * len(self.window_size))
+            self.padding = (0,) * len(self.window_size)
         else:
             self.padding = padding
 
@@ -28,20 +27,20 @@ class SpatialMaxPooling(df.Module):
 
             height_width_shape = symb_input.shape[-2:]
 
-            batch_size = _T.prod(symb_input.shape[:-2])
-            batch_size = _T.shape_padright(batch_size, 1)
+            batch_size = df.T.prod(symb_input.shape[:-2])
+            batch_size = df.T.shape_padright(batch_size, 1)
 
-            new_shape = _T.cast(_T.join(0, batch_size, _T.as_tensor([1,]), height_width_shape), 'int32')
+            new_shape = df.T.cast(df.T.join(0, batch_size, df.T.as_tensor([1,]), height_width_shape), 'int32')
 
-            input_4d = _T.reshape(symb_input, new_shape, ndim=4)
+            input_4d = df.T.reshape(symb_input, new_shape, ndim=4)
 
             # downsample height and width first
             # other dimensions contribute to batch_size
-            op = _T.signal.downsample.DownsampleFactorMax(self.window_size[1:], self.ignore_border, st=self.stride[1:], padding=self.padding[1:])
+            op = df.T.signal.downsample.DownsampleFactorMax(self.window_size[1:], self.ignore_border, st=self.stride[1:], padding=self.padding[1:])
             output = op(input_4d)
 
-            outshape = _T.join(0, symb_input.shape[:-2], output.shape[-2:])
-            out = _T.reshape(output, outshape, ndim=symb_input.ndim)
+            outshape = df.T.join(0, symb_input.shape[:-2], output.shape[-2:])
+            out = df.T.reshape(output, outshape, ndim=symb_input.ndim)
 
             vol_dim = symb_input.ndim
 
@@ -49,26 +48,26 @@ class SpatialMaxPooling(df.Module):
             input_depth = out.dimshuffle(shufl)
             vol_shape = input_depth.shape[-2:]
 
-            batch_size = _T.prod(input_depth.shape[:-2])
-            batch_size = _T.shape_padright(batch_size,1)
+            batch_size = df.T.prod(input_depth.shape[:-2])
+            batch_size = df.T.shape_padright(batch_size,1)
 
-            new_shape = _T.cast(_T.join(0, batch_size, _T.as_tensor([1,]), vol_shape), 'int32')
-            input_4D_depth = _T.reshape(input_depth, new_shape, ndim=4)
+            new_shape = df.T.cast(df.T.join(0, batch_size, df.T.as_tensor([1,]), vol_shape), 'int32')
+            input_4D_depth = df.T.reshape(input_depth, new_shape, ndim=4)
 
             # downsample depth
             # other dimensions contribute to batch_size
-            op = _T.signal.downsample.DownsampleFactorMax((1,self.window_size[0]), self.ignore_border, st=(1,self.stride[0]), padding=(0, self.padding[0]))
+            op = df.T.signal.downsample.DownsampleFactorMax((1,self.window_size[0]), self.ignore_border, st=(1,self.stride[0]), padding=(0, self.padding[0]))
             outdepth = op(input_4D_depth)
 
-            outshape = _T.join(0, input_depth.shape[:-2], outdepth.shape[-2:])
+            outshape = df.T.join(0, input_depth.shape[:-2], outdepth.shape[-2:])
             shufl = (list(range(vol_dim-4)) + [vol_dim-2]+[vol_dim-1]+[vol_dim-4]+[vol_dim-3])
 
-            return _T.reshape(outdepth, outshape, ndim=symb_input.ndim).dimshuffle(shufl)
+            return df.T.reshape(outdepth, outshape, ndim=symb_input.ndim).dimshuffle(shufl)
         else:
             return max_pool_2d(
-                    symb_input,
-                    ds=self.window_size,
-                    ignore_border=self.ignore_border,
-                    st=self.stride,
-                    padding=self.padding
-                    )
+                symb_input,
+                ds=self.window_size,
+                ignore_border=self.ignore_border,
+                st=self.stride,
+                padding=self.padding
+            )

--- a/DeepFried2/layers/SpatialMaxPoolingCUDNN.py
+++ b/DeepFried2/layers/SpatialMaxPoolingCUDNN.py
@@ -12,7 +12,7 @@ class SpatialMaxPoolingCUDNN(df.Module):
             self.stride = stride
 
         if padding is None:
-            self.padding = tuple([0]*len(window_size))
+            self.padding = (0,)*len(window_size)
         else:
             self.padding = padding
 

--- a/DeepFried2/utils.py
+++ b/DeepFried2/utils.py
@@ -1,6 +1,7 @@
 import DeepFried2 as df
 import numpy as _np
 from warnings import warn as _warn
+from numbers import Number as _Number
 
 
 def create_param(shape, init, fan=None, name=None, type=df.floatX):
@@ -72,12 +73,24 @@ def aslist(what):
         return [what]
 
 
+def expand(tup, ndim, expand_nonnum=False, name=None):
+    if isinstance(tup, (tuple, list)) and len(tup) == ndim:
+        return tup
+
+    if isinstance(tup, _Number) or expand_nonnum:
+        return (tup,) * ndim
+
+    if not expand_nonnum:
+        return tup
+
+    raise ValueError("Bad number of dimensions{}: is {} but should be {}.".format((" for " + name) if name else "", len(tup), ndim))
+
 def typename(obj):
     return type(obj).__name__
 
 
 def pad(symb_input, padding):
-    assert symb_input.ndim == len(padding), "symb_input and padding must have the same dimensionality"
+    assert symb_input.ndim == len(padding), "symb_input ({}d) and padding ({}d) must have the same dimensionality".format(symb_input.ndim, len(padding))
 
     padded_shape = tuple((s+2*p) for s,p in zip(symb_input.shape, padding))
     padded_input = df.T.zeros(padded_shape)


### PR DESCRIPTION
As a bonus, `'same'` convolution without CUDNN should now also work for 3D, as it's reformulated using `valid`.

This is a PR so it can be commented on later, but I'll merge it immediately.

ping @elPistolero
