### PR TITLE
Add support for extra outputs and `StoreIO`.

### DIFF
--- a/DeepFried2/Container.py
+++ b/DeepFried2/Container.py
@@ -30,6 +30,9 @@ class Container(df.Module):
         # e.g. do weight sharing.
         return list(_OrderedDict.fromkeys(params).keys())
 
+    def get_extra_outputs(self):
+        return list(_chain.from_iterable(m.get_extra_outputs() for m in self.modules))
+
     def get_stat_updates(self):
         return list(_chain.from_iterable(m.get_stat_updates() for m in self.modules))
 
@@ -56,3 +59,13 @@ class Container(df.Module):
     def __setstate__(self, state):
         for m, s in zip(self.modules, state):
             m.__setstate__(s)
+
+
+class SingleModuleContainer(Container):
+    def __init__(self, module):
+        Container.__init__(self, module)
+
+    def add(self, mod):
+        if len(self.modules):
+            raise TypeError("Container `{}` can't hold more than one module.".format(df.utils.typename(self)))
+        Container.add(self, mod)

--- a/DeepFried2/__init__.py
+++ b/DeepFried2/__init__.py
@@ -9,7 +9,7 @@ from .Param import Param
 from .Module import Module
 from .layers import *
 
-from .Container import Container
+from .Container import Container, SingleModuleContainer
 from .containers import *
 
 from .Criterion import Criterion

--- a/DeepFried2/containers/StoreIO.py
+++ b/DeepFried2/containers/StoreIO.py
@@ -1,0 +1,45 @@
+import DeepFried2 as df
+
+
+class StoreIO(df.SingleModuleContainer):
+    def __init__(self, module, inp=True, out=True):
+        df.SingleModuleContainer.__init__(self, module)
+
+        # We need to store them in dicts where the current mode is the key.
+        # That's because we will have different instances in different modes.
+        self._inp = {} if inp else None
+        self._out = {} if out else None
+
+    def symb_forward(self, symb_inp):
+        symb_out = self.modules[0].symb_forward(symb_inp)
+
+        if self._inp is not None:
+            self._inp[self.training_mode] = symb_inp
+        if self._out is not None:
+            self._out[self.training_mode] = symb_out
+
+        return symb_out
+
+    def get_extra_outputs(self):
+        return (df.utils.aslist(self._inp[self.training_mode], none_to_empty=True)
+               +df.utils.aslist(self._out[self.training_mode], none_to_empty=True))
+
+    @property
+    def out(self):
+        assert self._out is not None, "You want to look at the output you forbad to store?"
+
+        _out = self._out[self.training_mode]
+        if isinstance(_out, (list, tuple)):
+            return [o.val for o in _out]
+        else:
+            return _out.val
+
+    @property
+    def inp(self):
+        assert self._inp is not None, "You want to look at the input you forbad to store?"
+
+        _inp = self._inp[self.training_mode]
+        if isinstance(_inp, (list, tuple)):
+            return [o.val for o in _inp]
+        else:
+            return _inp.val

--- a/DeepFried2/containers/__init__.py
+++ b/DeepFried2/containers/__init__.py
@@ -1,3 +1,4 @@
 from .Sequential import Sequential
 from .Parallel import Parallel
 from .Concat import Concat
+from .StoreIO import StoreIO

--- a/DeepFried2/tests/containers/test_StoreIO.py
+++ b/DeepFried2/tests/containers/test_StoreIO.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+
+import DeepFried2 as df
+
+import unittest
+import numpy as np
+
+class TestStoreIO(unittest.TestCase):
+
+    def test(self):
+        net = df.StoreIO(df.Linear(2,3))
+
+        net.training()
+        X = np.array([[1,2],[3,4]], dtype=df.floatX)
+        Y = net.forward(X)
+        np.testing.assert_array_equal(net.inp, X)
+        np.testing.assert_array_equal(net.out, Y)
+
+        net.evaluate()
+        X = np.array([[10,20],[30,40]], dtype=df.floatX)
+        Y = net.forward(X)
+        np.testing.assert_array_equal(net.inp, X)
+        np.testing.assert_array_equal(net.out, Y)
+
+    def testMulti(self):
+        net = df.StoreIO(df.Identity())
+
+        net.training()
+        X = np.array([[1,2],[3,4]], dtype=df.floatX)
+        Y1, Y2 = net.forward([X, X*2])
+        np.testing.assert_array_equal(net.inp[0], X)
+        np.testing.assert_array_equal(net.inp[1], X*2)
+        np.testing.assert_array_equal(net.out[0], Y1)
+        np.testing.assert_array_equal(net.out[1], Y2)
+
+        net.evaluate()
+        X = np.array([[10,20],[30,40]], dtype=df.floatX)
+        Y1, Y2 = net.forward([X, X*2])
+        np.testing.assert_array_equal(net.inp[0], X)
+        np.testing.assert_array_equal(net.inp[1], X*2)
+        np.testing.assert_array_equal(net.out[0], Y1)
+        np.testing.assert_array_equal(net.out[1], Y2)

--- a/DeepFried2/utils.py
+++ b/DeepFried2/utils.py
@@ -37,11 +37,13 @@ def count_params(module, trainable_only=True):
     return sum(p.get_value().size for p in module.parameters(trainable_only=trainable_only))
 
 
-def aslist(what):
+def aslist(what, none_to_empty=False):
     if isinstance(what, list):
         return what
     elif isinstance(what, tuple):
         return list(what)
+    elif none_to_empty and what is None:
+        return []
     else:
         return [what]
 


### PR DESCRIPTION
Wanted this for a long time, but finally needed it and no possible workaround, so here it is :)

This adds a mechanism for layers to  `get_extra_outputs`. After `forward` or `accumulate_gradients` is run (no `accumulate_statistics` for now), all variables returned by `get_extra_outputs` will have an attribute `val` which stores its value.

Maybe looking at the the new `StoreIO` container module and its unittests of is most useful, but a quick teaser:

```
net = df.Sequential(df.StoreIO(df.Linear(2,3)), df.SoftMax())
net.forward(np.random.randn(1,2).astype(df.floatX))
print(net[0].inp)  # Shows input values to `Linear`
print(net[0].out)  # Shows output values of `Linear`
```

Maybe at some point we can turn this in/out storing into a generic flag in `Module`, but let's first roll with this one for some time and see.
