### PR TITLE
Add `Flatten` layer.

### DIFF
--- a/DeepFried2/layers/Flatten.py
+++ b/DeepFried2/layers/Flatten.py
@@ -1,0 +1,11 @@
+import DeepFried2 as df
+
+
+class Flatten(df.Module):
+    def __init__(self, ndim=2):
+        df.Module.__init__(self)
+        self.ndim = ndim
+
+    def symb_forward(self, symb_input):
+        return symb_input.flatten(self.ndim)
+

--- a/DeepFried2/layers/__init__.py
+++ b/DeepFried2/layers/__init__.py
@@ -7,6 +7,7 @@ from .Bias import Bias
 from .Log import Log
 from .ReLU import ReLU
 from .Reshape import Reshape
+from .Flatten import Flatten
 from .Permute import Permute
 from .Sigmoid import Sigmoid
 from .SoftMax import SoftMax


### PR DESCRIPTION
This is too common of an operation (before the first FC layer in any ConvNet) that it's too annoying to always write it as `df.Reshape(-1, [complex expression])`. It's much simpler to just `df.Flatten()`.
