### PR TITLE
Make using varying criteria work until #86.

### DIFF
--- a/DeepFried2/tests/test_Module.py
+++ b/DeepFried2/tests/test_Module.py
@@ -1,0 +1,21 @@
+#!/usr/bin/env python3
+
+import DeepFried2 as df
+
+import unittest
+import numpy as np
+
+class TestModule(unittest.TestCase):
+
+    def testDifferentCriteriaInstances(self):
+        T = np.random.randn(10,10).astype(df.floatX)
+        c1 = df.MSECriterion()
+        c2 = df.MADCriterion()
+        err = 0.5
+
+        net = df.Identity()
+        l1 = float(net.accumulate_gradients(T+err, T, c1))
+        l2 = float(net.accumulate_gradients(T+err, T, c2))
+
+        np.testing.assert_almost_equal(l1, err**2)
+        np.testing.assert_almost_equal(l2, abs(err))


### PR DESCRIPTION
Note that this make it slower if the criterion is always constructed on-the-fly as it will always have a different ID. It's not perfect either, but a slow-down on "misuse" is better than wrong values on "misuse".

ping @yobibyte this should fix the issue you had today, so I'm merging right away.
