### PR TITLE
Split Parallel into Parallel and RepeatInput.

### DIFF
--- a/DeepFried2/containers/Parallel.py
+++ b/DeepFried2/containers/Parallel.py
@@ -3,9 +3,6 @@ import DeepFried2 as df
 
 class Parallel(df.Container):
     def symb_forward(self, symb_input):
-        # TODO: Not sure if this polymorphism is any good!
-        if isinstance(symb_input, (list, tuple)):
-            assert len(symb_input) == len(self.modules), "If `{}` has multiple inputs, it should be the same amount as it has modules.".format(df.utils.typename(self))
-            return tuple(module(symb_in) for module, symb_in in zip(self.modules, symb_input))
-        else:
-            return tuple(module(symb_input) for module in self.modules)
+        assert isinstance(symb_input, (list, tuple)), "`{}` must have >1 inputs".format(df.utils.typename(self))
+        assert len(symb_input) == len(self.modules), "`{}` should have the same number of inputs ({}) as modules ({}).".format(df.utils.typename(self), len(symb_input), len(self.modules))
+        return tuple(module(symb_in) for module, symb_in in zip(self.modules, symb_input))

--- a/DeepFried2/containers/RepeatInput.py
+++ b/DeepFried2/containers/RepeatInput.py
@@ -1,0 +1,6 @@
+import DeepFried2 as df
+
+
+class RepeatInput(df.Container):
+    def symb_forward(self, symb_input):
+        return tuple(module(symb_input) for module in self.modules)

--- a/DeepFried2/containers/__init__.py
+++ b/DeepFried2/containers/__init__.py
@@ -1,5 +1,6 @@
 from .Sequential import Sequential
 from .Parallel import Parallel
+from .RepeatInput import RepeatInput
 from .Concat import Concat
 from .StoreOut import StoreOut
 from .ActiveIn import ActiveIn, InactiveIn, TrainingOnly, TestingOnly

--- a/DeepFried2/zoo/resnet.py
+++ b/DeepFried2/zoo/resnet.py
@@ -13,7 +13,7 @@ class Add(df.Module):
 
 def block(nchan, fs=(3,3), body=None):
     return df.Sequential(
-        df.Parallel(
+        df.RepeatInput(
             df.Sequential(
                 df.BatchNormalization(nchan), df.ReLU(),
                 df.SpatialConvolutionCUDNN(nchan, nchan, fs, border='same', init=df.init.prelu(), bias=False),
@@ -28,7 +28,7 @@ def block(nchan, fs=(3,3), body=None):
 
 def block_proj(nin, nout, fs=(3,3), body=None):
     return df.Sequential(
-        df.Parallel(
+        df.RepeatInput(
             df.Sequential(
                 df.BatchNormalization(nin), df.ReLU(),
                 df.SpatialConvolutionCUDNN(nin, nout, fs, border='same', init=df.init.prelu(), bias=False),


### PR DESCRIPTION
This removes the inherent disambiguity between them, and subtle mistakes.