### PR TITLE
A whole bunch of sanity-checks in parameter loading.

### DIFF
--- a/DeepFried2/Container.py
+++ b/DeepFried2/Container.py
@@ -64,6 +64,9 @@ class Container(df.Module):
         return [m.__getstate__() for m in self.modules]
 
     def __setstate__(self, state):
+        if len(self.modules) != len(state):
+            raise ValueError("{} wants to load params for {} modules but received params for {} modules".format(df.utils.typename(self), len(self.modules), len(state)))
+
         for m, s in zip(self.modules, state):
             m.__setstate__(s)
 

--- a/DeepFried2/Module.py
+++ b/DeepFried2/Module.py
@@ -189,5 +189,12 @@ class Module(object):
         return [p.get_value() for p in self.parameters()]
 
     def __setstate__(self, state):
-        for p, s in zip(self.parameters(), state):
+        params = self.parameters()
+        if len(params) != len(state):
+            raise ValueError("{} wants to load {} params but received {} params".format(df.utils.typename(self), len(params), len(state)))
+
+        for p, s in zip(params, state):
+            if p.get_value().shape != s.shape:
+                raise ValueError("{} got invalid shape when loading param {}: expecting {} but loading {}".format(df.utils.typename(self), p.param.name, p.get_value().shape, s.shape))
+
             p.set_value(s)

--- a/DeepFried2/layers/BatchNormalization.py
+++ b/DeepFried2/layers/BatchNormalization.py
@@ -107,7 +107,6 @@ class BatchNormalization(df.Module):
         return [buf.get_value() for buf in (self.buf_mean, self.buf_var, self.buf_count)] + regular
 
     def __setstate__(self, state):
-        istate = iter(state)
-        for buf, val in zip((self.buf_mean, self.buf_var, self.buf_count), istate):
+        for buf, val in zip((self.buf_mean, self.buf_var, self.buf_count), state):
             buf.set_value(val)
-        df.Module.__setstate__(self, istate)
+        df.Module.__setstate__(self, state[3:])


### PR DESCRIPTION
These will help avoid obscure mistakes when the loaded pickle doesn't correspond to the current model 1:1.